### PR TITLE
fix: package.json point to a different git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "github",
     "url": "https://github.com/sponsors/gregberge"
   },
-  "repository": "github:gregberge/react-merge-refs",
+  "repository": "github:gregberge/std-mocks",
   "author": "Bergé Greg <berge.greg@gmail.com>",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This must prevent https://www.npmjs.com/package/std-mocks from displaying the wrong repository & homepage URLs for this npm module, see below:

![imagen](https://github.com/gregberge/std-mocks/assets/1280022/dd56e72a-894d-4351-8648-cb9a79da7ad0)

