### PR TITLE
docs: correct repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "github",
     "url": "https://github.com/sponsors/gregberge"
   },
-  "repository": "github:gregberge/react-merge-refs",
+  "repository": "github:gregberge/std-mocks",
   "author": "Bergé Greg <berge.greg@gmail.com>",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
The repository url was incorrect, causing tools like `renovate`, and the npm autogenerated docs, to be a bit confused.

This PR corrects it.